### PR TITLE
Fix a display bug for charts

### DIFF
--- a/frontend/app/charts/page.js
+++ b/frontend/app/charts/page.js
@@ -151,8 +151,18 @@ const Home = () => {
   };
 
   const ZkalcGraph = () => {
-    let samples = getEstimates(defaultCurve, defaultLib, defaultMachine)[op];
-    if (typeof samples === "undefined") {
+    let allSamples = baseData((x) => x);
+    let samples = undefined;
+    let allUndef = true;
+    for (let i = 0; i < allSamples.length; i++) {
+      if (typeof allSamples[i] !== "undefined") {
+        samples = allSamples[i];
+        allUndef = false;
+        break;
+      }
+    }
+    
+    if (allUndef) {
       return <Row align={"center"}>Unavailable</Row>;
     }
     if (samples.range.length > 1) {


### PR DESCRIPTION
In the current version of zkalc, for example, if you want to display the chart : BLS-381 Inversion over Fp using AWS EC2 m5.2xlarge, it prints "Unavaible". It is because in `frontend/app/charts/page.js`, ZkalcGraph tests only the availability of the default curve, library and machine for an op whereas the op can be available on other curve curve or machine.

This PR fixes the bug.
